### PR TITLE
[✨ Feat] / #6 / 예산설정 API POST method 개발

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -39,3 +39,12 @@ class LoginSerializer(serializers.Serializer):
             raise serializers.ValidationError('A user with this email and password was not found')
         
         return {'username': user.username, 'user': user}
+    
+
+class UserTotalUpdateSerializer(serializers.Serializer):
+    total = serializers.IntegerField()
+    
+    def update(self, instance, validated_data):
+        instance.total = validated_data.get('total', instance.total)
+        instance.save()
+        return instance

--- a/budgets/serializers.py
+++ b/budgets/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
-from django.contrib.auth import authenticate
 
 from budgets.models import Category, Budget
 
@@ -10,5 +9,17 @@ User = get_user_model()
 class CategorySerializer(serializers.ModelSerializer):
     
     class Meta():
-        model=Category
+        model = Category
         fields = '__all__'
+
+
+class BudgetCreateSerializer(serializers.ModelSerializer):
+    
+    class Meta():
+        model = Budget
+        fields = '__all__'
+    
+    def create(self, validated_data):
+        budget = Budget.objects.create(**validated_data)
+        return budget
+    

--- a/budgets/urls.py
+++ b/budgets/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from budgets.views import CategoryListView
+from budgets.views import CategoryListView, BudgetsView
 
 app_name = "budgets"
 # base_url: api/budgets/
 
 urlpatterns =[
-    path("", CategoryListView.as_view())
+    # path("", CategoryListView.as_view()),
+    path("", BudgetsView.as_view()),
 ]

--- a/budgets/views.py
+++ b/budgets/views.py
@@ -1,18 +1,89 @@
-
-from rest_framework.generics import ListAPIView
-from rest_framework.permissions import AllowAny, IsAuthenticated
 from django.shortcuts import render
 
-from budgets.models import Budget, Category
-from budgets.serializers import CategorySerializer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework import status
+
+from accounts.serializers import UserTotalUpdateSerializer
+from budgets.models import Budget, Category, REC_LIST, BUDGET_REC_RATIO
+from budgets.serializers import CategorySerializer, BudgetCreateSerializer
 
 
 class CategoryListView(ListAPIView):
     '''
+    method: GET
+    소비 카테고리 리스트 반환
     '''
     permission_classes = [AllowAny,]
     # permission_classes = [IsAuthenticated,]
     
     serializer_class = CategorySerializer
     queryset = Category.objects.all().order_by('id')
+
+
+class BudgetsView(APIView):
+    '''
+    method: GET, POST, PATCH
+    '''
     
+    # permission_classes = [AllowAny, ]
+    permission_classes = [IsAuthenticated,]
+    
+    def get(self, request):
+        '''
+        소비 카테고리 리스트 반환
+        '''
+        queryset = Category.objects.all().order_by('id')
+        serializer = CategorySerializer(queryset, many=True)
+        
+        return Response({
+            "message": "get categories",
+            "data": serializer.data},
+            status=status.HTTP_200_OK
+            )
+    
+    def post(self, request):
+        '''
+        예산 종목별 금액입력
+        '''
+        data = request.data
+        budget_list = data.get('budget_list', None)
+        result = []
+        total = 0
+        user = request.user
+        
+        ## TODO-같은 카테고리 들어왔을 때 처리 추가 필요.
+        # 동혁님. unique_together? unique_constrain?
+        # djagno 복합key 설정 못함. 단일 key설정임
+        # 이 복합 key 대신 두 필드에 unique를 걸어주는 것.
+        if budget_list:
+            for budget in budget_list:
+                total += budget.get("amount", 0)
+                budget["user"] = user.pk
+                serializer = BudgetCreateSerializer(data=budget)
+                if serializer.is_valid():
+                    result.append(serializer.create(serializer.validated_data).pk)
+        
+        total_serializer = UserTotalUpdateSerializer(data={'total': total})
+        if total_serializer.is_valid():
+            user = total_serializer.update(user, total_serializer.validated_data)
+
+        return Response({
+            "message": "budget create success!",
+            "setup_user": user.pk,
+            "setup_user_total": user.total,
+            "data": result
+            },
+            status=status.HTTP_201_CREATED
+            )
+
+    def patch(self, request, ):
+        '''
+        예산 수정
+        '''
+        ## 여러개 레코드가 생기는데.. 어떻게 수정을 해야할지 고민중..
+        ## 원래거 전체 삭제하고 전체 싹다 받아서 해야하나요
+        pass
+


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]기능 추가
- [x]기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/#6 -> dev

### 변경 사항
- 유저 total 설정 serializer 개발
- 기존 카테고리 리스트 반환 API URL 수정
- 예산설정 API 예산 레코드 생성 부분 개발

### 테스트 결과
- json의 list 형태로 들어온 예산 목록의 레코드가 생성됨을 확인
- 입력 형식: budget_list 키 안에 list로 전달됨
```json
{
    "budget_list": [
        {
            "category": 2,
            "amount": 30
        },
        {
            "category": 3,
            "amount": 50
        },
        {
            "category": 4,
            "amount": 20
        }
    ]
}
```