### PR TITLE
[✨ Feat] / #9 / -2 지출 CRUD API 개발 - 목록조회 기능추가

### DIFF
--- a/expenditures/views.py
+++ b/expenditures/views.py
@@ -1,3 +1,7 @@
+import math
+import copy
+from datetime import date, datetime, timedelta
+
 from django.shortcuts import render, get_object_or_404
 
 from rest_framework.views import APIView
@@ -9,6 +13,12 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from expenditures.models import Expenditure
 from expenditures.serializers import ExpenditureSerializer, ExpenditureCreateSerializer, ExpenditureUpdateSerializer
 
+from budgets.models import CATEGORIES
+
+STATIC_FORM = dict.fromkeys(CATEGORIES.keys(), {"count":0, "sum":0})
+DICT_FORM = {"count":0, "sum":0}
+
+
 class ExpenditureListCreateView(APIView):
     permission_classes = [IsAuthenticated, ]
     
@@ -18,10 +28,44 @@ class ExpenditureListCreateView(APIView):
         '''
         user = request.user
         queryset = Expenditure.objects.filter(user=user.pk)
+        
+        query_params = request.query_params
+        start = query_params.get("start", str(date.today() - timedelta(days=30)))
+        end = query_params.get("end", str(date.today()))
+        category = query_params.get("category", "all")
+        min_amount = query_params.get("min", 0)
+        max_amount = query_params.get("max", 9999999999) ## 예산 최대값을 어떻게 정할 수 있을까?
+        
+        start_date = datetime.strptime(start, '%Y-%m-%d')
+        end_date =  datetime.strptime(end, '%Y-%m-%d')
+        end_date = end_date + timedelta(days=1)
+        
+        queryset = queryset.filter(created_at__gte=start_date, created_at__lt=end_date, amount__gte=min_amount, amount__lt=max_amount)
+        
+        if category != "all":
+            queryset = queryset.filter(category=category)
+        
         serializer = ExpenditureSerializer(queryset, many=True)
         result = serializer.data
+        
+        ## 리스트 통계 데이터 생성
+        statistics = dict()
+        temp_list = list()
+        for keyname in CATEGORIES.keys():
+            temp_list.append({keyname: copy.deepcopy(DICT_FORM)})
+            
+        statistics["category_group"] = temp_list
+        total = 0
+        for q in list(queryset):
+            total += q.amount
+            for d in statistics["category_group"]:
+                if d.get(q.category.name, None):
+                    d[q.category.name]["count"] += 1
+                    d[q.category.name]["sum"] += q.amount
+        
+        statistics["total_sum"] = total
 
-        return Response({"message": "sucess!", "data": result}, status=status.HTTP_200_OK)
+        return Response({"message": "success!", "data": result, "static_data":statistics}, status=status.HTTP_200_OK)
     
     def post(self, request):
         '''
@@ -29,7 +73,6 @@ class ExpenditureListCreateView(APIView):
         
         {
             "category" : 4,
-            "
         }
         '''
         user = request.user


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]기능 추가
- []기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/#9-2 -> dev

### 변경 사항
- 지출 CRUD 중 지출 목록 조회 API 추가개발
- 기간, 카테고리, 금액 별로 쿼리 파라메터를 받아서 원하는 범위에서 조회 가능하도록 개발

### 테스트 결과
- 쿼리문이 없이도 기본값들을 설정하여 기본 기간(30일, 모든 카테고리, 모든 금액범위) 로 검색하도록 개발
- 조회된 지출 목록들에 대한 카테고리별 소비 금액 및 소비 건 수, 전체 소비금액의 통계 데이터 생성
- 통계 데이터를 리스폰스로 전송(지출 목록은 `data` 키로 전송, 통계데이터는 `static_data` 키로 전송)
```json
## 통계데이터 출력
"static_data": {
        "category_group": [
            {
                "undefined": {
                    "count": 0,
                    "sum": 0
                }
            },
            {
                "쇼핑": {
                    "count": 2,
                    "sum": 42000
                }
            },
            {
                "교통": {
                    "count": 2,
                    "sum": 55300
                }
            },
            {
                "주거비": {
                    "count": 1,
                    "sum": 25000
                }
            },
            {
                "취미": {
                    "count": 3,
                    "sum": 204000
                }
            },
            {
                "교육": {
                    "count": 0,
                    "sum": 0
                }
            },
            {
                "병원": {
                    "count": 0,
                    "sum": 0
                }
            },
            {
                "식비": {
                    "count": 0,
                    "sum": 0
                }
            },
            {
                "저축/투자": {
                    "count": 0,
                    "sum": 0
                }
            }
        ],
        "total_sum": 326300
    }
```