### PR TITLE
[bug:Fix] #10 v2/ 지출추천 API calendar 적용하여 날짜 정확도 개선 및 로직오류 수정

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -26,7 +26,10 @@ class User(AbstractUser):
     email = None
     updated_at = models.DateTimeField(auto_now=True)
     total = models.PositiveIntegerField(default=0)
-    start_date = models.PositiveIntegerField(default=1, validators=[MinValueValidator(1), MaxValueValidator(30)])
+    # per_day = models.PositiveIntegerField(default=5000)
+    start_date = models.PositiveIntegerField(
+        default=1, 
+        validators=[MinValueValidator(1), MaxValueValidator(30)])
     
     USERNAME_FIELD = "username"
     REQUIRED_FIELDS = []


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]기능 추가
- [x]기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feat/#10-2 -> dev

### 변경 사항
- 지출 컨설팅 - 오늘 지출 추천 API 개선 및 오류 수정
  - calendar 적용하여 날짜에 대한 정확도를 높임
  - 잘못된 계산 방식을 수정하여 정확하게 계산하도록 수정
  - 예산에서 현재 사용한 금액을 제외한 금액을 남은 일수대비로 계산하여 추천
  - 예산을 넘기더라도 최소금액을 3330으로 지정
  - 카테고리 추천 금액에 최소금액 지정시 전체금액에도 반영하도록 함
- 소비 통계정보 함수 이름 수정

### 테스트 결과
```json
## 데이터 출력
{
    "message": "today(2023-11-18)s message: you have to save your money!",
    "data": {
        "today_recommand": 99390,
        "period": "2023-11-01 00:00:00 ~ 2023-11-18 00:00:00",
        "쇼핑": 23600,
        "교통": 3400,
        "주거비": 13400,
        "취미": 3330,
        "식비": 19200,
        "저축/투자": 0
    }
}
```